### PR TITLE
Add content interface for device profiles

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -34,7 +34,12 @@ apps:
       DEVICE_PROFILESDIR: "$SNAP_DATA/config/device-rfid-llrp-go/res"
     daemon: simple
     plugs: [network, network-bind]
-
+slots:
+  device-profiles-slot:
+    interface: content
+    content: device-profiles
+    write:
+    - $SNAP_DATA/config/device-rfid-llrp-go/res
 parts:
   go:
     plugin: nil


### PR DESCRIPTION
Add content interface for device profiles

Add a content interface, so that a gadget snap can configure the
required device profiles.

See README.md in https://github.com/siggiskulason/test-device-content-interfaces
for a sample snap which connects to the content interface and uploads
a new device profile

Signed-off-by: Siggi Skulason <siggi.skulason@canonical.com>
