### PR TITLE
fix(snap): remove hook passthru

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -27,23 +27,6 @@ architectures:
     - build-on: arm64
     - build-on: amd64
 
-passthrough:
-  hooks:
-    connect-plug-network-observe:
-      command-chain:
-        - snap/command-chain/snapcraft-runner
-      plugs:
-        - network
-        - network-observe
-        - network-control
-    connect-plug-network-control:
-      command-chain:
-        - snap/command-chain/snapcraft-runner
-      plugs:
-        - network
-        - network-observe
-        - network-control
-
 apps:
    device-rfid-llrp-go:
     adapter: none


### PR DESCRIPTION
This change removes the passthru stanza for the
connect-* hooks which were removed in an earlier
commit, as snapd complains about the missing hooks
and prevents the snap from being installed.

Signed-off-by: Tony Espy <espy@canonical.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [NA] Tests for the changes have been added (for bug fixes / features)
- [NA] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number:


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?
No

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
